### PR TITLE
feat: add workflow_dispatch trigger to scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,5 +1,6 @@
 name: Update OSSF Scorecard
 on:
+  workflow_dispatch:
   # For Branch-Protection check. Only the default branch is supported. See
   # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
   branch_protection_rule:


### PR DESCRIPTION
## Summary

Added `workflow_dispatch` trigger to the OSSF Scorecard workflow. This allows the scorecard workflow to be manually triggered from the GitHub Actions UI, in addition to its existing automated triggers (branch protection rules, scheduled runs, and push events to main).

### Checklist

- [x] Fill out all sections of this pull request description
- [x] Assign this pull request to yourself
- [x] Add the following labels to this pull request:
    - [x] `effort: *` to describe the amount of effort required to review this pull request
    - [x] `type: *` to describe the type of change introduced in this pull request
    - [x] `work: *` to describe the complexity of the changes introduced by this pull request
- [x] Add at least one issue closed by this pull request. (If this pull request does not close an issue, consider adding an issue first.)

## Testing

The change is minimal and only adds a new trigger configuration to the workflow file. No functionality changes were made to the actual workflow execution. The syntax has been validated against GitHub Actions workflow schema.

## Issues

Closes #35